### PR TITLE
response! macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+//#![cfg_attr(not(doc), no_main)]
+#![feature(macro_metavar_expr)]
 pub mod assets;
 pub mod responses;
 pub mod submessages;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-//#![cfg_attr(not(doc), no_main)]
-#![feature(macro_metavar_expr)]
 pub mod assets;
 pub mod responses;
 pub mod submessages;

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -14,59 +14,86 @@ pub fn merge_responses(responses: Vec<Response>) -> Response {
     merged
 }
 
-/// Macro for generating Response objects with Events, Attributes and Messages
-///
-/// Variants
-///  - response!() - returns a new, empty Response
-///  - response!("event") - returns a new Response with Event named "event"
-///  - response!(resp, "event") - attaches Event "event" to Response `resp`
-///  - response!("event", [(k, v), (j, u), ...]) - returns Response with
-///    Event "event" and Attributes from series (not array) of tuples
-///  - response!(resp, "event", [(k, v), (j, u), ...]) - same as above but
-///    attaching to existing Response `resp`
-///  - response!("event", [(k, v), (j, u), ...], [m, n, ...]) - returns Response
-///    with Event "event", Attributes `(k, v)` etc., and Messages `m`, `n`, etc.
-///  - response!(resp, "event", [(k, v), (j, u), ...], [m, n, ...]) - same as
-///    above but attached to Response `resp`
+/// Super-macro for creating the prefix in Events that might differ from contract to contract
+/// Simply call `response_prefix!("foo/bar")`, which expands to a definition `response!` with
+/// "foo/bar" as the prefix. The subsequent Events will be named "foo/bar/<event name>".
 #[macro_export]
-macro_rules! response {
-    () => {
-        cosmwasm_std::Response::new()
-    };
-    ( $response:expr, $event_name:literal, [ $( ($key:literal, $value:expr) ),* ] ) => {
-        {
-            // needed because things get weird with macros
-            #[allow(unused_mut)]
-            let mut attrs: Vec<cosmwasm_std::Attribute> = Vec::new();
-            $(
-                attrs.push(cosmwasm_std::attr($key, $value));
-            )*
-            let event = cosmwasm_std::Event::new(
-                    format!("{}/{}", "apollo/vaults",
-                    String::from($event_name)))
-                .add_attributes(attrs.clone());
-            $response.add_attributes(attrs).add_event(event)
+macro_rules! response_prefix {
+    ( $prefix:literal ) => {
+        /// Macro for generating Response objects with Events, Attributes and Messages
+        ///
+        /// Variants
+        ///  - response!() - returns a new, empty Response
+        ///  - response!("event") - returns a new Response with Event named "event"
+        ///  - response!(resp, "event") - attaches Event "event" to Response `resp`
+        ///  - response!("event", [(k, v), (j, u), ...]) - returns Response with
+        ///    Event "event" and Attributes from series (not array) of tuples
+        ///  - response!(resp, "event", [(k, v), (j, u), ...]) - same as above but
+        ///    attaching to existing Response `resp`
+        ///  - response!("event", [(k, v), (j, u), ...], [m, n, ...]) - returns Response
+        ///    with Event "event", Attributes `(k, v)` etc., and Messages `m`, `n`, etc.
+        ///  - response!(resp, "event", [(k, v), (j, u), ...], [m, n, ...]) - same as
+        ///    above but attached to Response `resp`
+        macro_rules! response {
+            () => {
+                cosmwasm_std::Response::<cosmwasm_std::Empty>::new()
+            };
+            ( $$response:expr, $$event_name:literal, [ $$( ($$key:literal, $$value:expr) ),* ] ) => {
+                {
+                    // needed because things get weird with macros
+                    #[allow(unused_mut)]
+                    let mut attrs: Vec<cosmwasm_std::Attribute> = Vec::new();
+                    $$(
+                        attrs.push(cosmwasm_std::attr($$key, $$value));
+                    )*
+                    let event = cosmwasm_std::Event::new(
+                            format!("{}/{}",
+                            String::from($prefix),
+                            String::from($$event_name)))
+                        .add_attributes(attrs.clone());
+                    $$response.add_attributes(attrs).add_event(event)
+                }
+            };
+            ( $$response:expr, $$event_name:literal ) => {
+                response!($$response, $$event_name, [])
+            };
+            ( $$event_name:literal ) => {
+                response!(response!(), $$event_name)
+            };
+            ( $$event_name:literal, [ $$( ($$key:literal, $$value:expr) ),* ] ) => {
+                response!(response!(), $$event_name, [ $$(($$key, $$value)),* ])
+            };
+            ( $$response:expr, $$event_name:literal, [ $$( ($$key:literal, $$value:expr) ),* ], [ $$( $$msg:expr ),* ] ) => {
+                {
+                    let mut msgs = Vec::new();
+                    $$(
+                        msgs.push($$msg);
+                    )*
+                    response!($$response, $$event_name, [ $$(($$key, $$value)),* ]).add_messages(msgs)
+                }
+            };
+            ( $$event_name:literal, [ $$( ($$key:literal, $$value:expr) ),* ], [ $$( $$msg:expr ),* ] ) => {
+                response!(response!(), $$event_name, [ $$(($$key, $$value)),* ], [$$($$msg),*])
+            };
         }
     };
-    ( $response:expr, $event_name:literal ) => {
-        response!($response, $event_name, [])
-    };
-    ( $event_name:literal ) => {
-        response!(response!(), $event_name)
-    };
-    ( $event_name:literal, [ $( ($key:literal, $value:expr) ),* ] ) => {
-        response!(response!(), $event_name, [ $(($key, $value)),* ])
-    };
-    ( $response:expr, $event_name:literal, [ $( ($key:literal, $value:expr) ),* ], [ $( $msg:expr ),* ] ) => {
-        {
-            let mut msgs = Vec::new();
-            $(
-                msgs.push($msg);
-            )*
-            response!($response, $event_name, [ $(($key, $value)),* ]).add_messages(msgs)
-        }
-    };
-    ( $event_name:literal, [ $( ($key:literal, $value:expr) ),* ], [ $( $msg:expr ),* ] ) => {
-        response!(response!(), $event_name, [ $(($key, $value)),* ], [$($msg),*])
-    };
+}
+
+#[cfg(test)]
+mod tests {
+    use cosmwasm_std::{Attribute, CosmosMsg, Empty, Event, Response};
+
+    response_prefix!("apollo/test");
+
+    #[test]
+    fn test_empty_response() {
+        let resp = Response::<Empty>::new();
+        assert_eq!(resp, response!())
+    }
+
+    #[test]
+    fn test_response_event() {
+        let event = response!("test").events[0].clone();
+        assert_eq!(Event::new("apollo/test/test"), event)
+    }
 }

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -14,66 +14,79 @@ pub fn merge_responses(responses: Vec<Response>) -> Response {
     merged
 }
 
+// Utility macro for response_prefix! macro below
+#[macro_export]
+macro_rules! with_dollar_sign {
+    ( $( $body:tt )* ) => {
+        macro_rules! __with_dollar_sign { $($body)* }
+        __with_dollar_sign!($);
+    }
+}
+
 /// Super-macro for creating the prefix in Events that might differ from contract to contract
 /// Simply call `response_prefix!("foo/bar")`, which expands to a definition `response!` with
 /// "foo/bar" as the prefix. The subsequent Events will be named "foo/bar/<event name>".
 #[macro_export]
 macro_rules! response_prefix {
     ( $prefix:literal ) => {
-        /// Macro for generating Response objects with Events, Attributes and Messages
-        ///
-        /// Variants
-        ///  - response!() - returns a new, empty Response
-        ///  - response!("event") - returns a new Response with Event named "event"
-        ///  - response!(resp, "event") - attaches Event "event" to Response `resp`
-        ///  - response!("event", [(k, v), (j, u), ...]) - returns Response with
-        ///    Event "event" and Attributes from series (not array) of tuples
-        ///  - response!(resp, "event", [(k, v), (j, u), ...]) - same as above but
-        ///    attaching to existing Response `resp`
-        ///  - response!("event", [(k, v), (j, u), ...], [m, n, ...]) - returns Response
-        ///    with Event "event", Attributes `(k, v)` etc., and Messages `m`, `n`, etc.
-        ///  - response!(resp, "event", [(k, v), (j, u), ...], [m, n, ...]) - same as
-        ///    above but attached to Response `resp`
-        macro_rules! response {
-            () => {
-                cosmwasm_std::Response::<cosmwasm_std::Empty>::new()
-            };
-            ( $$response:expr, $$event_name:literal, [ $$( ($$key:literal, $$value:expr) ),* ] ) => {
-                {
-                    // needed because things get weird with macros
-                    #[allow(unused_mut)]
-                    let mut attrs: Vec<cosmwasm_std::Attribute> = Vec::new();
-                    $$(
-                        attrs.push(cosmwasm_std::attr($$key, $$value));
-                    )*
-                    let event = cosmwasm_std::Event::new(
-                            format!("{}/{}",
-                            String::from($prefix),
-                            String::from($$event_name)))
-                        .add_attributes(attrs.clone());
-                    $$response.add_attributes(attrs).add_event(event)
+        with_dollar_sign! {
+            ( $d:tt ) => {
+                /// Macro for generating Response objects with Events, Attributes and Messages
+                ///
+                /// Variants
+                ///  - response!() - returns a new, empty Response
+                ///  - response!("event") - returns a new Response with Event named "event"
+                ///  - response!(resp, "event") - attaches Event "event" to Response `resp`
+                ///  - response!("event", [(k, v), (j, u), ...]) - returns Response with
+                ///    Event "event" and Attributes from series (not array) of tuples
+                ///  - response!(resp, "event", [(k, v), (j, u), ...]) - same as above but
+                ///    attaching to existing Response `resp`
+                ///  - response!("event", [(k, v), (j, u), ...], [m, n, ...]) - returns Response
+                ///    with Event "event", Attributes `(k, v)` etc., and Messages `m`, `n`, etc.
+                ///  - response!(resp, "event", [(k, v), (j, u), ...], [m, n, ...]) - same as
+                ///    above but attached to Response `resp`
+                macro_rules! response {
+                    () => {
+                        cosmwasm_std::Response::<cosmwasm_std::Empty>::new()
+                    };
+                    ( $d response:expr, $d event_name:literal, [ $d( ($d key:literal, $d value:expr) ),* ] ) => {
+                        {
+                            // needed because things get weird with macros
+                            #[allow(unused_mut)]
+                            let mut attrs: Vec<cosmwasm_std::Attribute> = Vec::new();
+                            $d(
+                                attrs.push(cosmwasm_std::attr($d key, $d value));
+                            )*
+                            let event = cosmwasm_std::Event::new(
+                                    format!("{}/{}",
+                                    String::from($prefix),
+                                    String::from($d event_name)))
+                                .add_attributes(attrs.clone());
+                            $d response.add_attributes(attrs).add_event(event)
+                        }
+                    };
+                    ( $d response:expr, $d event_name:literal ) => {
+                        response!($d response, $d event_name, [])
+                    };
+                    ( $d event_name:literal ) => {
+                        response!(response!(), $d event_name)
+                    };
+                    ( $d event_name:literal, [ $d( ($d key:literal, $d value:expr) ),* ] ) => {
+                        response!(response!(), $d event_name, [ $d(($d key, $d value)),* ])
+                    };
+                    ( $d response:expr, $d event_name:literal, [ $d( ($d key:literal, $d value:expr) ),* ], [ $d( $d msg:expr ),* ] ) => {
+                        {
+                            let mut msgs = Vec::new();
+                            $d(
+                                msgs.push($d msg);
+                            )*
+                            response!($d response, $d event_name, [ $d(($d key, $d value)),* ]).add_messages(msgs)
+                        }
+                    };
+                    ( $d event_name:literal, [ $d( ($d key:literal, $d value:expr) ),* ], [ $d( $d msg:expr ),* ] ) => {
+                        response!(response!(), $d event_name, [ $d(($d key, $d value)),* ], [$d($d msg),*])
+                    };
                 }
-            };
-            ( $$response:expr, $$event_name:literal ) => {
-                response!($$response, $$event_name, [])
-            };
-            ( $$event_name:literal ) => {
-                response!(response!(), $$event_name)
-            };
-            ( $$event_name:literal, [ $$( ($$key:literal, $$value:expr) ),* ] ) => {
-                response!(response!(), $$event_name, [ $$(($$key, $$value)),* ])
-            };
-            ( $$response:expr, $$event_name:literal, [ $$( ($$key:literal, $$value:expr) ),* ], [ $$( $$msg:expr ),* ] ) => {
-                {
-                    let mut msgs = Vec::new();
-                    $$(
-                        msgs.push($$msg);
-                    )*
-                    response!($$response, $$event_name, [ $$(($$key, $$value)),* ]).add_messages(msgs)
-                }
-            };
-            ( $$event_name:literal, [ $$( ($$key:literal, $$value:expr) ),* ], [ $$( $$msg:expr ),* ] ) => {
-                response!(response!(), $$event_name, [ $$(($$key, $$value)),* ], [$$($$msg),*])
             };
         }
     };

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -82,7 +82,7 @@ macro_rules! response_prefix {
                     };
                     ( $d response:expr, $d event_name:literal, [ $d( ($d key:literal, $d value:expr) ),* ], [ $d( $d msg:expr ),* ] ) => {
                         {
-                            let mut msgs = Vec::new();
+                            let mut msgs: Vec<cosmwasm_std::CosmosMsg> = Vec::new();
                             $d(
                                 msgs.push($d msg);
                             )*
@@ -91,6 +91,18 @@ macro_rules! response_prefix {
                     };
                     ( $d event_name:literal, [ $d( ($d key:literal, $d value:expr) ),* ], [ $d( $d msg:expr ),* ] ) => {
                         response!(response!(), $d event_name, [ $d(($d key, $d value)),* ], [$d($d msg),*])
+                    };
+                    ( $d response:expr, $d event_name:literal, [ $d( ($d key:literal, $d value:expr) ),* ], [ $d( $d msg:expr ),* ], [ $d( $d submsg:expr ),* ] ) => {
+                        {
+                            let mut submsgs: Vec<cosmwasm_std::SubMsg> = Vec::new();
+                            $d(
+                                submsgs.push($d submsg);
+                            )*
+                            response!($d response, $d event_name, [ $d(($d key, $d value)),* ], [$d($d msg),*]).add_submessages(submsgs)
+                        }
+                    };
+                    ( $d event_name:literal, [ $d( ($d key:literal, $d value:expr) ),* ], [ $d( $d msg:expr ),* ], [ $d( $d submsg:expr ),* ] ) => {
+                        response!(response!(), $d event_name, [ $d(($d key, $d value)),* ], [$d($d msg),*], [$d($d submsg),*])
                     };
                 }
             };

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -52,9 +52,11 @@ macro_rules! response_prefix {
                 ///  - `response!(resp, "event", [(k, v), (j, u), ...], [m, n, ...])` - same as
                 ///    above but attached to Response `resp`
                 macro_rules! response {
+                    // ()
                     () => {
                         cosmwasm_std::Response::<cosmwasm_std::Empty>::new()
                     };
+                    // (response, event, [attrs])
                     ( $d response:expr, $d event_name:literal, [ $d( ($d key:literal, $d value:expr) ),* ] ) => {
                         {
                             // needed because things get weird with macros
@@ -71,15 +73,19 @@ macro_rules! response_prefix {
                             $d response.add_attributes(attrs).add_event(event)
                         }
                     };
+                    // (response, event)
                     ( $d response:expr, $d event_name:literal ) => {
                         response!($d response, $d event_name, [])
                     };
+                    // (event)
                     ( $d event_name:literal ) => {
                         response!(response!(), $d event_name)
                     };
+                    // (event, [attrs])
                     ( $d event_name:literal, [ $d( ($d key:literal, $d value:expr) ),* ] ) => {
                         response!(response!(), $d event_name, [ $d(($d key, $d value)),* ])
                     };
+                    // (response, event, [attrs], [msgs])
                     ( $d response:expr, $d event_name:literal, [ $d( ($d key:literal, $d value:expr) ),* ], [ $d( $d msg:expr ),* ] ) => {
                         {
                             let mut msgs: Vec<cosmwasm_std::CosmosMsg> = Vec::new();
@@ -89,9 +95,11 @@ macro_rules! response_prefix {
                             response!($d response, $d event_name, [ $d(($d key, $d value)),* ]).add_messages(msgs)
                         }
                     };
+                    // (event, [attrs], [msgs])
                     ( $d event_name:literal, [ $d( ($d key:literal, $d value:expr) ),* ], [ $d( $d msg:expr ),* ] ) => {
                         response!(response!(), $d event_name, [ $d(($d key, $d value)),* ], [$d($d msg),*])
                     };
+                    // (response, event, [attrs], [msgs], [submsgs])
                     ( $d response:expr, $d event_name:literal, [ $d( ($d key:literal, $d value:expr) ),* ], [ $d( $d msg:expr ),* ], [ $d( $d submsg:expr ),* ] ) => {
                         {
                             let mut submsgs: Vec<cosmwasm_std::SubMsg> = Vec::new();
@@ -101,6 +109,7 @@ macro_rules! response_prefix {
                             response!($d response, $d event_name, [ $d(($d key, $d value)),* ], [$d($d msg),*]).add_submessages(submsgs)
                         }
                     };
+                    // (event, [attrs], [msgs], [submsgs])
                     ( $d event_name:literal, [ $d( ($d key:literal, $d value:expr) ),* ], [ $d( $d msg:expr ),* ], [ $d( $d submsg:expr ),* ] ) => {
                         response!(response!(), $d event_name, [ $d(($d key, $d value)),* ], [$d($d msg),*], [$d($d submsg),*])
                     };

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -13,3 +13,60 @@ pub fn merge_responses(responses: Vec<Response>) -> Response {
     }
     merged
 }
+
+/// Macro for generating Response objects with Events, Attributes and Messages
+///
+/// Variants
+///  - response!() - returns a new, empty Response
+///  - response!("event") - returns a new Response with Event named "event"
+///  - response!(resp, "event") - attaches Event "event" to Response `resp`
+///  - response!("event", [(k, v), (j, u), ...]) - returns Response with
+///    Event "event" and Attributes from series (not array) of tuples
+///  - response!(resp, "event", [(k, v), (j, u), ...]) - same as above but
+///    attaching to existing Response `resp`
+///  - response!("event", [(k, v), (j, u), ...], [m, n, ...]) - returns Response
+///    with Event "event", Attributes `(k, v)` etc., and Messages `m`, `n`, etc.
+///  - response!(resp, "event", [(k, v), (j, u), ...], [m, n, ...]) - same as
+///    above but attached to Response `resp`
+#[macro_export]
+macro_rules! response {
+    () => {
+        cosmwasm_std::Response::new()
+    };
+    ( $response:expr, $event_name:literal, [ $( ($key:literal, $value:expr) ),* ] ) => {
+        {
+            // needed because things get weird with macros
+            #[allow(unused_mut)]
+            let mut attrs: Vec<cosmwasm_std::Attribute> = Vec::new();
+            $(
+                attrs.push(cosmwasm_std::attr($key, $value));
+            )*
+            let event = cosmwasm_std::Event::new(
+                    format!("{}/{}", "apollo/vaults",
+                    String::from($event_name)))
+                .add_attributes(attrs.clone());
+            $response.add_attributes(attrs).add_event(event)
+        }
+    };
+    ( $response:expr, $event_name:literal ) => {
+        response!($response, $event_name, [])
+    };
+    ( $event_name:literal ) => {
+        response!(response!(), $event_name)
+    };
+    ( $event_name:literal, [ $( ($key:literal, $value:expr) ),* ] ) => {
+        response!(response!(), $event_name, [ $(($key, $value)),* ])
+    };
+    ( $response:expr, $event_name:literal, [ $( ($key:literal, $value:expr) ),* ], [ $( $msg:expr ),* ] ) => {
+        {
+            let mut msgs = Vec::new();
+            $(
+                msgs.push($msg);
+            )*
+            response!($response, $event_name, [ $(($key, $value)),* ]).add_messages(msgs)
+        }
+    };
+    ( $event_name:literal, [ $( ($key:literal, $value:expr) ),* ], [ $( $msg:expr ),* ] ) => {
+        response!(response!(), $event_name, [ $(($key, $value)),* ], [$($msg),*])
+    };
+}


### PR DESCRIPTION
Adds a macro `response!` that avoids boilerplate and facilitates less verbose `Response`-building with custom `Event`s, `Attribute`s and `Message`s. Used in apollo-vaults and cw-dex.

Signed-off-by: Bobby <bobby@apollo.farm>